### PR TITLE
Go bindings for the machine API

### DIFF
--- a/machines.go
+++ b/machines.go
@@ -95,8 +95,8 @@ type MachineMatrixInformation struct {
 type MachineProfile struct {
 	Info struct {
 		machineInfo
-		Maker                 maker      `json:"maker"`
-		Maker2                maker      `json:"maker2"`
+		MakerPrimary          maker      `json:"maker"`
+		MakerSecondary        maker      `json:"maker2"`
 		AuthUserTimeOwnedUser string     `json:"authUserFirstUserTime"`
 		AuthUserTimeOwnedRoot string     `json:"authUserFirstRootTime"`
 		FirstBloodInUser      firstBlood `json:"userBlood"`


### PR DESCRIPTION
This branch contains the following changes:
- Added a bind to retrieve the profile of a machine
- Added a bind to retrieve the matrix of a machine
- Added a bind to retrieve the list of active machines
- Added a bind to retrieve the list of retired machines

### To do
- [ ] Add a binder for retrieving the list of scheduled machines to be released.
- [ ] Add a binder for retrieving the list of to-do machines by the authenticated user.
- [ ] Add a binder for retrieving a machine's information (not including the first blood data)
- [ ] Add a binder for retrieving the top 25 users in a machine.
- [ ] Add a binder for retrieving the tags of a machine.
- [ ] Add a binder to retrieve the changelog of a machine.
- [ ] Add a binder to retrieve official writeups of a machine.
- [ ] Add a binder to retrieve the authenticated user's active machine.