### PR TITLE
Moved duplicates to their original structs

### DIFF
--- a/machines.go
+++ b/machines.go
@@ -1,66 +1,67 @@
 package htbgo
 
-type maker struct {
-	ID                  int    `json:"id"`
-	Name                string `json:"name"`
-	Avatar              string `json:"avatar"`
-	AuthUserSentRespect bool   `json:"isRespected"`
-}
-type user struct {
-	Name   string `json:"name"`
-	ID     int    `json:"id"`
-	Avatar string `json:"avatar"`
-}
+// type maker struct {
+// 	ID                  int    `json:"id"`
+// 	Name                string `json:"name"`
+// 	Avatar              string `json:"avatar"`
+// 	AuthUserSentRespect bool   `json:"isRespected"`
+// }
 
-type firstBlood struct {
-	User               user   `json:"user"`
-	MachineCreatedAt   string `json:"created_at"`
-	FirstBloodDuration string `json:"blood_difference"`
-}
+// type user struct {
+// 	Name   string `json:"name"`
+// 	ID     int    `json:"id"`
+// 	Avatar string `json:"avatar"`
+// }
 
-type machineInfo struct {
-	ID                  int    `json:"id"`
-	Name                string `json:"name"`
-	OS                  string `json:"os"`
-	IsTodo              bool   `json:"isTodo"`
-	Active              int    `json:"active"`
-	Retired             int    `json:"retired"`
-	IP                  string `json:"ip"`
-	Points              int    `json:"points"`
-	StaticPoints        int    `json:"static_points"`
-	Release             string `json:"release"`
-	UserOwnCounts       int    `json:"user_owns_count"`
-	RootOwnCounts       int    `json:"root_owns_count"`
-	Free                bool   `json:"free"`
-	AuthUserIfUserOwns  bool   `json:"authUserInUserOwns"`
-	AuthUserIfRootOwns  bool   `json:"authUserInRootOwns"`
-	AuthUserHasReviewed bool   `json:"authUserHasReviewed"`
-	Stars               string `json:"stars"`
-	Difficulty          int    `json:"difficulty"`
-	Avatar              string `json:"avatar"`
-	FeedbackChart       struct {
-		CakeDifficulty      int `json:"counterCake"`
-		VeryEasyDifficulty  int `json:"counterVeryEasy"`
-		EasyDifficulty      int `json:"counterEasy"`
-		TooEasyDifficulty   int `json:"counterTooEasy"`
-		MediumDifficulty    int `json:"counterMedium"`
-		BitHardDifficulty   int `json:"counterBitHard"`
-		HardDifficulty      int `json:"counterHard"`
-		TooHardDifficulty   int `json:"counterTooHard"`
-		ExtraHardDifficulty int `json:"counterExHard"`
-		BrainFuckDifficulty int `json:"counterBrainFuck"`
-	} `json:"feedbackForChart"`
-	DifficultyText string `json:"difficultyText"`
-	IsCompleted    bool   `json:"isCompleted"`
-	LastResetTime  string `json:"last_reset_time"`
-	PlayInfo       struct {
-		IsSpawned         bool   `json:"isSpawned"`
-		IsSpawning        bool   `json:"isSpawning"`
-		IsActive          bool   `json:"isActive"`
-		ActivePlayerCount int    `json:"active_player_count"`
-		ExpiresAt         string `json:"expires_at"`
-	}
-}
+// type firstBlood struct {
+// 	User               user   `json:"user"`
+// 	MachineCreatedAt   string `json:"created_at"`
+// 	FirstBloodDuration string `json:"blood_difference"`
+// }
+
+// type machineInfo struct {
+// 	ID                  int    `json:"id"`
+// 	Name                string `json:"name"`
+// 	OS                  string `json:"os"`
+// 	IsTodo              bool   `json:"isTodo"`
+// 	Active              int    `json:"active"`
+// 	Retired             int    `json:"retired"`
+// 	IP                  string `json:"ip"`
+// 	Points              int    `json:"points"`
+// 	StaticPoints        int    `json:"static_points"`
+// 	Release             string `json:"release"`
+// 	UserOwnCounts       int    `json:"user_owns_count"`
+// 	RootOwnCounts       int    `json:"root_owns_count"`
+// 	Free                bool   `json:"free"`
+// 	AuthUserIfUserOwns  bool   `json:"authUserInUserOwns"`
+// 	AuthUserIfRootOwns  bool   `json:"authUserInRootOwns"`
+// 	AuthUserHasReviewed bool   `json:"authUserHasReviewed"`
+// 	Stars               string `json:"stars"`
+// 	Difficulty          int    `json:"difficulty"`
+// 	Avatar              string `json:"avatar"`
+// 	FeedbackChart       struct {
+// 		CakeDifficulty      int `json:"counterCake"`
+// 		VeryEasyDifficulty  int `json:"counterVeryEasy"`
+// 		EasyDifficulty      int `json:"counterEasy"`
+// 		TooEasyDifficulty   int `json:"counterTooEasy"`
+// 		MediumDifficulty    int `json:"counterMedium"`
+// 		BitHardDifficulty   int `json:"counterBitHard"`
+// 		HardDifficulty      int `json:"counterHard"`
+// 		TooHardDifficulty   int `json:"counterTooHard"`
+// 		ExtraHardDifficulty int `json:"counterExHard"`
+// 		BrainFuckDifficulty int `json:"counterBrainFuck"`
+// 	} `json:"feedbackForChart"`
+// 	DifficultyText string `json:"difficultyText"`
+// 	IsCompleted    bool   `json:"isCompleted"`
+// 	LastResetTime  string `json:"last_reset_time"`
+// 	PlayInfo       struct {
+// 		IsSpawned         bool   `json:"isSpawned"`
+// 		IsSpawning        bool   `json:"isSpawning"`
+// 		IsActive          bool   `json:"isActive"`
+// 		ActivePlayerCount int    `json:"active_player_count"`
+// 		ExpiresAt         string `json:"expires_at"`
+// 	}
+// }
 
 // Get Machine Matrix
 // https://www.hackthebox.com/api/v4/machine/graph/matrix/{machineID}
@@ -94,31 +95,219 @@ type MachineMatrixInformation struct {
 // https://www.hackthebox.com/api/v4/machine/info/{machineID}
 type MachineProfile struct {
 	Info struct {
-		machineInfo
-		MakerPrimary          maker      `json:"maker"`
-		MakerSecondary        maker      `json:"maker2"`
-		AuthUserTimeOwnedUser string     `json:"authUserFirstUserTime"`
-		AuthUserTimeOwnedRoot string     `json:"authUserFirstRootTime"`
-		FirstBloodInUser      firstBlood `json:"userBlood"`
-		UserFirstBloodAvatar  string     `json:"userBloodAvatar"`
-		FirstBloodInRoot      firstBlood `json:"rootBlood"`
-		RootFirstBloodAvatar  string     `json:"rootBloodAvatar"`
-		UserFirstBloodTime    string     `json:"firstUserBloodTime"`
-		RootFirstBloodTime    string     `json:"firstRootBloodTime"`
-		Recommended           int        `json:"recommended"`
+		ID                  int    `json:"id"`
+		Name                string `json:"name"`
+		OS                  string `json:"os"`
+		Active              int    `json:"active"`
+		Retired             int    `json:"retired"`
+		IP                  string `json:"ip"`
+		Points              int    `json:"points"`
+		StaticPoints        int    `json:"static_points"`
+		Release             string `json:"release"`
+		UserOwnCounts       int    `json:"user_owns_count"`
+		RootOwnCounts       int    `json:"root_owns_count"`
+		Free                bool   `json:"free"`
+		AuthUserIfUserOwns  bool   `json:"authUserInUserOwns"`
+		AuthUserIfRootOwns  bool   `json:"authUserInRootOwns"`
+		AuthUserHasReviewed bool   `json:"authUserHasReviewed"`
+		Stars               string `json:"stars"`
+		Difficulty          int    `json:"difficulty"`
+		Avatar              string `json:"avatar"`
+		FeedbackChart       struct {
+			CakeDifficulty      int `json:"counterCake"`
+			VeryEasyDifficulty  int `json:"counterVeryEasy"`
+			EasyDifficulty      int `json:"counterEasy"`
+			TooEasyDifficulty   int `json:"counterTooEasy"`
+			MediumDifficulty    int `json:"counterMedium"`
+			BitHardDifficulty   int `json:"counterBitHard"`
+			HardDifficulty      int `json:"counterHard"`
+			TooHardDifficulty   int `json:"counterTooHard"`
+			ExtraHardDifficulty int `json:"counterExHard"`
+			BrainFuckDifficulty int `json:"counterBrainFuck"`
+		} `json:"feedbackForChart"`
+		DifficultyText string `json:"difficultyText"`
+		IsCompleted    bool   `json:"isCompleted"`
+		LastResetTime  string `json:"last_reset_time"`
+		PlayInfo       struct {
+			IsSpawned         bool   `json:"isSpawned"`
+			IsSpawning        bool   `json:"isSpawning"`
+			IsActive          bool   `json:"isActive"`
+			ActivePlayerCount int    `json:"active_player_count"`
+			ExpiresAt         string `json:"expires_at"`
+		} `json:"playInfo"`
+
+		MakerPrimary struct {
+			ID                  int    `json:"id"`
+			Name                string `json:"name"`
+			Avatar              string `json:"avatar"`
+			AuthUserSentRespect bool   `json:"isRespected"`
+		} `json:"maker"`
+
+		MakerSecondary struct {
+			ID                  int    `json:"id"`
+			Name                string `json:"name"`
+			Avatar              string `json:"avatar"`
+			AuthUserSentRespect bool   `json:"isRespected"`
+		} `json:"maker2"`
+
+		AuthUserTimeOwnedUser string `json:"authUserFirstUserTime"`
+		AuthUserTimeOwnedRoot string `json:"authUserFirstRootTime"`
+		FirstBloodInUser      struct {
+			User struct {
+				Name   string `json:"name"`
+				ID     int    `json:"id"`
+				Avatar string `json:"avatar"`
+			} `json:"user"`
+
+			MachineCreatedAt   string `json:"created_at"`
+			FirstBloodDuration string `json:"blood_difference"`
+		} `json:"userBlood"`
+		UserFirstBloodAvatar string `json:"userBloodAvatar"`
+		FirstBloodInRoot     struct {
+			User struct {
+				Name   string `json:"name"`
+				ID     int    `json:"id"`
+				Avatar string `json:"avatar"`
+			} `json:"user"`
+
+			MachineCreatedAt   string `json:"created_at"`
+			FirstBloodDuration string `json:"blood_difference"`
+		} `json:"rootBlood"`
+
+		RootFirstBloodAvatar string `json:"rootBloodAvatar"`
+		UserFirstBloodTime   string `json:"firstUserBloodTime"`
+		RootFirstBloodTime   string `json:"firstRootBloodTime"`
+		Recommended          int    `json:"recommended"`
 	}
 }
 
 //	Get Active Machines
 // https://www.hackthebox.com/api/v4/machine/list
 type ActiveMachines struct {
-	Info []machineInfo
+	Info []struct {
+		ID                  int    `json:"id"`
+		Name                string `json:"name"`
+		OS                  string `json:"os"`
+		Points              int    `json:"points"`
+		StaticPoints        int    `json:"static_points"`
+		Release             string `json:"release"`
+		UserOwnCounts       int    `json:"user_owns_count"`
+		RootOwnCounts       int    `json:"root_owns_count"`
+		AuthUserIfUserOwns  bool   `json:"authUserInUserOwns"`
+		AuthUserIfRootOwns  bool   `json:"authUserInRootOwns"`
+		IsTodo              bool   `json:"isTodo"`
+		AuthUserHasReviewed bool   `json:"authUserHasReviewed"`
+		Stars               string `json:"stars"`
+		Difficulty          int    `json:"difficulty"`
+		FeedbackChart       struct {
+			CakeDifficulty      int `json:"counterCake"`
+			VeryEasyDifficulty  int `json:"counterVeryEasy"`
+			EasyDifficulty      int `json:"counterEasy"`
+			TooEasyDifficulty   int `json:"counterTooEasy"`
+			MediumDifficulty    int `json:"counterMedium"`
+			BitHardDifficulty   int `json:"counterBitHard"`
+			HardDifficulty      int `json:"counterHard"`
+			TooHardDifficulty   int `json:"counterTooHard"`
+			ExtraHardDifficulty int `json:"counterExHard"`
+			BrainFuckDifficulty int `json:"counterBrainFuck"`
+		} `json:"feedbackForChart"`
+		Avatar         string `json:"avatar"`
+		DifficultyText string `json:"difficultyText"`
+		IsCompleted    bool   `json:"isCompleted"`
+		LastResetTime  string `json:"last_reset_time"`
+		PlayInfo       struct {
+			IsSpawned         bool   `json:"isSpawned"`
+			IsSpawning        bool   `json:"isSpawning"`
+			IsActive          bool   `json:"isActive"`
+			ActivePlayerCount int    `json:"active_player_count"`
+			ExpiresAt         string `json:"expires_at"`
+		} `json:"playInfo"`
+
+		Free         bool `json:"free"`
+		MakerPrimary struct {
+			ID                  int    `json:"id"`
+			Name                string `json:"name"`
+			Avatar              string `json:"avatar"`
+			AuthUserSentRespect bool   `json:"isRespected"`
+		} `json:"maker"`
+		MakerSecondary struct {
+			ID                  int    `json:"id"`
+			Name                string `json:"name"`
+			Avatar              string `json:"avatar"`
+			AuthUserSentRespect bool   `json:"isRespected"`
+		} `json:"maker2"`
+		Recommended int    `json:"recommended"`
+		SPFlag      int    `json:"sp_flag"`
+		EasyMonth   int    `json:"easy_month"`
+		IP          string `json:"ip"`
+	}
 }
 
 // Get Retired Machines
 // https://www.hackthebox.com/api/v4/machine/list/retired
 type RetiredMachines struct {
-	Info []machineInfo
+	Info []struct {
+		ID                  int    `json:"id"`
+		Name                string `json:"name"`
+		OS                  string `json:"os"`
+		Points              int    `json:"points"`
+		StaticPoints        int    `json:"static_points"`
+		Release             string `json:"release"`
+		UserOwnCounts       int    `json:"user_owns_count"`
+		RootOwnCounts       int    `json:"root_owns_count"`
+		AuthUserIfUserOwns  bool   `json:"authUserInUserOwns"`
+		AuthUserIfRootOwns  bool   `json:"authUserInRootOwns"`
+		IsTodo              bool   `json:"isTodo"`
+		AuthUserHasReviewed bool   `json:"authUserHasReviewed"`
+		Stars               string `json:"stars"`
+		Difficulty          int    `json:"difficulty"`
+		FeedbackChart       struct {
+			CakeDifficulty      int `json:"counterCake"`
+			VeryEasyDifficulty  int `json:"counterVeryEasy"`
+			EasyDifficulty      int `json:"counterEasy"`
+			TooEasyDifficulty   int `json:"counterTooEasy"`
+			MediumDifficulty    int `json:"counterMedium"`
+			BitHardDifficulty   int `json:"counterBitHard"`
+			HardDifficulty      int `json:"counterHard"`
+			TooHardDifficulty   int `json:"counterTooHard"`
+			ExtraHardDifficulty int `json:"counterExHard"`
+			BrainFuckDifficulty int `json:"counterBrainFuck"`
+		} `json:"feedbackForChart"`
+
+		Avatar         string `json:"avatar"`
+		DifficultyText string `json:"difficultyText"`
+		IsCompleted    bool   `json:"isCompleted"`
+		LastResetTime  string `json:"last_reset_time"`
+		PlayInfo       struct {
+			IsSpawned         bool   `json:"isSpawned"`
+			IsSpawning        bool   `json:"isSpawning"`
+			IsActive          bool   `json:"isActive"`
+			ActivePlayerCount int    `json:"active_player_count"`
+			ExpiresAt         string `json:"expires_at"`
+		} `json:"playInfo"`
+
+		Free         bool `json:"free"`
+		MakerPrimary struct {
+			ID                  int    `json:"id"`
+			Name                string `json:"name"`
+			Avatar              string `json:"avatar"`
+			AuthUserSentRespect bool   `json:"isRespected"`
+		} `json:"maker"`
+		MakerSecondary struct {
+			ID                  int    `json:"id"`
+			Name                string `json:"name"`
+			Avatar              string `json:"avatar"`
+			AuthUserSentRespect bool   `json:"isRespected"`
+		} `json:"maker2"`
+		Recommended int    `json:"recommended"`
+		SPFlag      int    `json:"sp_flag"`
+		EasyMonth   int    `json:"easy_month"`
+		IP          string `json:"ip"`
+		Tags        []struct {
+			ID             int `json:"id"`
+			TagCategoryIDs int `json:"tag_category_id"`
+		} `json:"tags"`
+	}
 }
 
 func (s *Session) MachineMatrix(machineID string) (matrix MachineMatrixInformation) {


### PR DESCRIPTION
I moved the duplicates to their original structs as @luxunator mentioned in #5.

Because the APIs have inconsistent fields, there would be a lot of empty fields if we apply the DRY method.